### PR TITLE
Add OrderedMap feature and update yaml encoding

### DIFF
--- a/encoding/yaml/yaml.go
+++ b/encoding/yaml/yaml.go
@@ -5,7 +5,7 @@ import (
 	"os"
 )
 
-func encodeAndSaveToFile(data interface{}, filename string) error {
+func encodeAndSaveToFile(data any, filename string) error {
 	file, err := os.Create(filename)
 	if err != nil {
 		return err
@@ -20,7 +20,7 @@ func encodeAndSaveToFile(data interface{}, filename string) error {
 	return encoder.Encode(data)
 }
 
-func decodeFromFile(filename string, out interface{}) error {
+func decodeFromFile(filename string, out any) error {
 	file, err := os.Open(filename)
 	if err != nil {
 		return err
@@ -35,11 +35,11 @@ func decodeFromFile(filename string, out interface{}) error {
 	return decoder.Decode(out)
 }
 
-func encodeToString(data interface{}) (string, error) {
+func encodeToString(data any) (string, error) {
 	bytes, err := yaml.Marshal(data)
 	return string(bytes), err
 }
 
-func decodeFromString(input string, out interface{}) error {
+func decodeFromString(input string, out any) error {
 	return yaml.Unmarshal([]byte(input), out)
 }

--- a/go.mod
+++ b/go.mod
@@ -7,15 +7,17 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/oklog/ulid/v2 v2.1.0
 	github.com/spf13/cobra v1.7.0
+	github.com/stretchr/testify v1.8.3
 	go.uber.org/zap v1.24.0
 	golang.org/x/crypto v0.12.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/stretchr/testify v1.8.3 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
 	golang.org/x/sys v0.11.0 // indirect

--- a/map/map.go
+++ b/map/map.go
@@ -1,0 +1,170 @@
+package orderedmap
+
+import (
+	"container/list"
+)
+
+type KeyError struct {
+	MissingKey any
+}
+
+type Pair struct {
+	Key     any
+	Value   any
+	element *list.Element
+}
+
+type OrderedMap struct {
+	pairs map[any]*Pair
+	list  *list.List
+}
+
+var _ error = &KeyError{}
+
+func (e *KeyError) Error() string {
+	return "KeyError: Key not found"
+}
+
+func NewOrderedMap() *OrderedMap {
+	return &OrderedMap{
+		pairs: make(map[any]*Pair),
+		list:  list.New(),
+	}
+}
+
+func (om *OrderedMap) GetWithPair(key any) (*Pair, bool) {
+	pair, ok := om.pairs[key]
+	return pair, ok
+}
+
+func (om *OrderedMap) Get(key any) (any, bool) {
+	pair, ok := om.GetWithPair(key)
+	if ok {
+		return pair.Value, true
+	}
+	return nil, false
+}
+
+func (om *OrderedMap) Load(key any) (any, bool) {
+	return om.Get(key)
+}
+
+func (om *OrderedMap) GetPair(key any) *Pair {
+	pair, _ := om.GetWithPair(key)
+	return pair
+}
+
+func (om *OrderedMap) Set(key any, value any) (any, bool) {
+	if pair, present := om.GetWithPair(key); present {
+		oldValue := pair.Value
+		pair.Value = value
+		return oldValue, true
+	}
+
+	pair := &Pair{
+		Key:   key,
+		Value: value,
+	}
+	pair.element = om.list.PushBack(pair)
+	om.pairs[key] = pair
+
+	return nil, false
+}
+
+func (om *OrderedMap) Store(key any, value any) (any, bool) {
+	return om.Set(key, value)
+}
+
+func (om *OrderedMap) Delete(key any) (any, bool) {
+	if pair, present := om.GetWithPair(key); present {
+		om.list.Remove(pair.element)
+		delete(om.pairs, key)
+		return pair.Value, true
+	}
+	return nil, false
+}
+
+func (om *OrderedMap) Len() int {
+	return len(om.pairs)
+}
+
+func (om *OrderedMap) Oldest() *Pair {
+	return listElementToPair(om.list.Front())
+}
+
+func (om *OrderedMap) Newest() *Pair {
+	return listElementToPair(om.list.Back())
+}
+
+func (p *Pair) Next() *Pair {
+	return listElementToPair(p.element.Next())
+}
+
+func (p *Pair) Prev() *Pair {
+	return listElementToPair(p.element.Prev())
+}
+
+func listElementToPair(element *list.Element) *Pair {
+	if element == nil {
+		return nil
+	}
+	return element.Value.(*Pair)
+}
+
+func (om *OrderedMap) getElements(keys ...any) ([]*list.Element, error) {
+	elements := make([]*list.Element, len(keys))
+	for i, k := range keys {
+		pair, present := om.GetWithPair(k)
+		if !present {
+			return nil, &KeyError{k}
+		}
+		elements[i] = pair.element
+	}
+	return elements, nil
+}
+
+// MoveAfter and MoveBefore functions factored to use helper function.
+func (om *OrderedMap) MoveAfter(key, markKey any) error {
+	return om.movePair(key, markKey, func(keyElement, markElement *list.Element) {
+		om.list.MoveAfter(keyElement, markElement)
+	})
+}
+
+func (om *OrderedMap) MoveBefore(key, markKey any) error {
+	return om.movePair(key, markKey, func(keyElement, markElement *list.Element) {
+		om.list.MoveBefore(keyElement, markElement)
+	})
+}
+
+func (om *OrderedMap) movePair(key, markKey any, moveFunc func(keyElement, markElement *list.Element)) error {
+	keyPair, keyOk := om.GetWithPair(key)
+	markPair, markOk := om.GetWithPair(markKey)
+
+	if !keyOk || !markOk {
+		return &KeyError{}
+	}
+
+	moveFunc(keyPair.element, markPair.element)
+
+	return nil
+}
+
+// MoveToBack gets error checked version.
+func (om *OrderedMap) MoveToBack(key any) error {
+	pair, present := om.GetWithPair(key)
+	if !present {
+		return &KeyError{key}
+	}
+	om.list.MoveToBack(pair.element)
+	return nil
+}
+
+// MoveToFront gets error checked version.
+func (om *OrderedMap) MoveToFront(key any) error {
+	pair, present := om.GetWithPair(key)
+	if !present {
+		return &KeyError{key}
+	}
+	om.list.MoveToFront(pair.element)
+	return nil
+}

--- a/map/map_test.go
+++ b/map/map_test.go
@@ -1,0 +1,316 @@
+package orderedmap
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBasicFeatures(t *testing.T) {
+	n := 100
+	om := NewOrderedMap()
+
+	// set(i, 2 * i)
+	for i := 0; i < n; i++ {
+		assertLenEqual(t, om, i)
+		oldValue, present := om.Set(i, 2*i)
+		assertLenEqual(t, om, i+1)
+
+		assert.Nil(t, oldValue)
+		assert.False(t, present)
+	}
+
+	// get what we just set
+	for i := 0; i < n; i++ {
+		value, present := om.Get(i)
+
+		assert.Equal(t, 2*i, value)
+		assert.True(t, present)
+	}
+
+	// get pairs of what we just set
+	for i := 0; i < n; i++ {
+		pair := om.GetPair(i)
+
+		assert.NotNil(t, pair)
+		assert.Equal(t, 2*i, pair.Value)
+	}
+
+	// forward iteration
+	i := 0
+	for pair := om.Oldest(); pair != nil; pair = pair.Next() {
+		assert.Equal(t, i, pair.Key)
+		assert.Equal(t, 2*i, pair.Value)
+		i++
+	}
+	// backward iteration
+	i = n - 1
+	for pair := om.Newest(); pair != nil; pair = pair.Prev() {
+		assert.Equal(t, i, pair.Key)
+		assert.Equal(t, 2*i, pair.Value)
+		i--
+	}
+
+	// forward iteration starting from known key
+	i = 42
+	for pair := om.GetPair(i); pair != nil; pair = pair.Next() {
+		assert.Equal(t, i, pair.Key)
+		assert.Equal(t, 2*i, pair.Value)
+		i++
+	}
+
+	// double values for pairs with even keys
+	for j := 0; j < n/2; j++ {
+		i = 2 * j
+		oldValue, present := om.Set(i, 4*i)
+
+		assert.Equal(t, 2*i, oldValue)
+		assert.True(t, present)
+	}
+	// and delete pairs with odd keys
+	for j := 0; j < n/2; j++ {
+		i = 2*j + 1
+		assertLenEqual(t, om, n-j)
+		value, present := om.Delete(i)
+		assertLenEqual(t, om, n-j-1)
+
+		assert.Equal(t, 2*i, value)
+		assert.True(t, present)
+
+		// deleting again shouldn't change anything
+		value, present = om.Delete(i)
+		assertLenEqual(t, om, n-j-1)
+		assert.Nil(t, value)
+		assert.False(t, present)
+	}
+
+	// get the whole range
+	for j := 0; j < n/2; j++ {
+		i = 2 * j
+		value, present := om.Get(i)
+		assert.Equal(t, 4*i, value)
+		assert.True(t, present)
+
+		i = 2*j + 1
+		value, present = om.Get(i)
+		assert.Nil(t, value)
+		assert.False(t, present)
+	}
+
+	// check iterations again
+	i = 0
+	for pair := om.Oldest(); pair != nil; pair = pair.Next() {
+		assert.Equal(t, i, pair.Key)
+		assert.Equal(t, 4*i, pair.Value)
+		i += 2
+	}
+	i = 2 * ((n - 1) / 2)
+	for pair := om.Newest(); pair != nil; pair = pair.Prev() {
+		assert.Equal(t, i, pair.Key)
+		assert.Equal(t, 4*i, pair.Value)
+		i -= 2
+	}
+}
+
+func TestUpdatingDoesntChangePairsOrder(t *testing.T) {
+	om := NewOrderedMap()
+	om.Set("foo", "bar")
+	om.Set(12, 28)
+	om.Set(78, 100)
+	om.Set("bar", "baz")
+
+	oldValue, present := om.Set(78, 102)
+	assert.Equal(t, 100, oldValue)
+	assert.True(t, present)
+
+	assertOrderedPairsEqual(t, om,
+		[]any{"foo", 12, 78, "bar"},
+		[]any{"bar", 28, 102, "baz"})
+}
+
+func TestDeletingAndReinsertingChangesPairsOrder(t *testing.T) {
+	om := NewOrderedMap()
+	om.Set("foo", "bar")
+	om.Set(12, 28)
+	om.Set(78, 100)
+	om.Set("bar", "baz")
+
+	// delete a pair
+	oldValue, present := om.Delete(78)
+	assert.Equal(t, 100, oldValue)
+	assert.True(t, present)
+
+	// re-insert the same pair
+	oldValue, present = om.Set(78, 100)
+	assert.Nil(t, oldValue)
+	assert.False(t, present)
+
+	assertOrderedPairsEqual(t, om,
+		[]any{"foo", 12, "bar", 78},
+		[]any{"bar", 28, "baz", 100})
+}
+
+func TestEmptyMapOperations(t *testing.T) {
+	om := NewOrderedMap()
+
+	oldValue, present := om.Get("foo")
+	assert.Nil(t, oldValue)
+	assert.False(t, present)
+
+	oldValue, present = om.Delete("bar")
+	assert.Nil(t, oldValue)
+	assert.False(t, present)
+
+	assertLenEqual(t, om, 0)
+
+	assert.Nil(t, om.Oldest())
+	assert.Nil(t, om.Newest())
+}
+
+type dummyTestStruct struct {
+	value string
+}
+
+func TestPackUnpackStructs(t *testing.T) {
+	om := NewOrderedMap()
+	om.Set("foo", dummyTestStruct{"foo!"})
+	om.Set("bar", dummyTestStruct{"bar!"})
+
+	value, present := om.Get("foo")
+	assert.True(t, present)
+	if assert.NotNil(t, value) {
+		assert.Equal(t, "foo!", value.(dummyTestStruct).value)
+	}
+
+	value, present = om.Set("bar", dummyTestStruct{"baz!"})
+	assert.True(t, present)
+	if assert.NotNil(t, value) {
+		assert.Equal(t, "bar!", value.(dummyTestStruct).value)
+	}
+
+	value, present = om.Get("bar")
+	assert.True(t, present)
+	if assert.NotNil(t, value) {
+		assert.Equal(t, "baz!", value.(dummyTestStruct).value)
+	}
+}
+
+// shamelessly stolen from https://github.com/python/cpython/blob/e19a91e45fd54a56e39c2d12e6aaf4757030507f/Lib/test/test_ordered_dict.py#L55-L61
+func TestShuffle(t *testing.T) {
+	ranLen := 100
+
+	for _, n := range []int{0, 10, 20, 100, 1000, 10000} {
+		t.Run(fmt.Sprintf("shuffle test with %d items", n), func(t *testing.T) {
+			om := NewOrderedMap()
+
+			keys := make([]any, n)
+			values := make([]any, n)
+
+			for i := 0; i < n; i++ {
+				// we prefix with the number to ensure that we don't get any duplicates
+				keys[i] = fmt.Sprintf("%d_%s", i, randomHexString(t, ranLen))
+				values[i] = randomHexString(t, ranLen)
+
+				value, present := om.Set(keys[i], values[i])
+				assert.Nil(t, value)
+				assert.False(t, present)
+			}
+
+			assertOrderedPairsEqual(t, om, keys, values)
+		})
+	}
+}
+
+/* Test helpers */
+
+func assertOrderedPairsEqual(t *testing.T, om *OrderedMap, expectedKeys, expectedValues []any) {
+	assertOrderedPairsEqualFromNewest(t, om, expectedKeys, expectedValues)
+	assertOrderedPairsEqualFromOldest(t, om, expectedKeys, expectedValues)
+}
+
+func assertOrderedPairsEqualFromNewest(t *testing.T, om *OrderedMap, expectedKeys, expectedValues []any) {
+	if assert.Equal(t, len(expectedKeys), len(expectedValues)) && assert.Equal(t, len(expectedKeys), om.Len()) {
+		i := om.Len() - 1
+		for pair := om.Newest(); pair != nil; pair = pair.Prev() {
+			assert.Equal(t, expectedKeys[i], pair.Key)
+			assert.Equal(t, expectedValues[i], pair.Value)
+			i--
+		}
+	}
+}
+
+func assertOrderedPairsEqualFromOldest(t *testing.T, om *OrderedMap, expectedKeys, expectedValues []any) {
+	if assert.Equal(t, len(expectedKeys), len(expectedValues)) && assert.Equal(t, len(expectedKeys), om.Len()) {
+		i := om.Len() - 1
+		for pair := om.Newest(); pair != nil; pair = pair.Prev() {
+			assert.Equal(t, expectedKeys[i], pair.Key)
+			assert.Equal(t, expectedValues[i], pair.Value)
+			i--
+		}
+	}
+}
+
+func assertLenEqual(t *testing.T, om *OrderedMap, expectedLen int) {
+	assert.Equal(t, expectedLen, om.Len())
+
+	// also check the list length, for good measure
+	assert.Equal(t, expectedLen, om.list.Len())
+}
+
+func randomHexString(t *testing.T, length int) string {
+	b := length / 2
+	randBytes := make([]byte, b)
+
+	if n, err := rand.Read(randBytes); err != nil || n != b {
+		if err == nil {
+			err = fmt.Errorf("only got %v random bytes, expected %v", n, b)
+		}
+		t.Fatal(err)
+	}
+
+	return hex.EncodeToString(randBytes)
+}
+
+func TestMove(t *testing.T) {
+	om := NewOrderedMap()
+	om.Set("1", "bar")
+	om.Set(2, 28)
+	om.Set(3, 100)
+	om.Set("4", "baz")
+	om.Set(5, "28")
+	om.Set(6, "100")
+	om.Set("7", "baz")
+	om.Set("8", "baz")
+
+	var err error
+
+	err = om.MoveAfter(2, 3)
+	assert.Nil(t, err)
+	assertOrderedPairsEqual(t, om,
+		[]any{"1", 3, 2, "4", 5, 6, "7", "8"},
+		[]any{"bar", 100, 28, "baz", "28", "100", "baz", "baz"})
+
+	err = om.MoveBefore(6, "4")
+	assert.Nil(t, err)
+	assertOrderedPairsEqual(t, om,
+		[]any{"1", 3, 2, 6, "4", 5, "7", "8"},
+		[]any{"bar", 100, 28, "100", "baz", "28", "baz", "baz"})
+
+	err = om.MoveToBack(3)
+	assert.Nil(t, err)
+	assertOrderedPairsEqual(t, om,
+		[]any{"1", 2, 6, "4", 5, "7", "8", 3},
+		[]any{"bar", 28, "100", "baz", "28", "baz", "baz", 100})
+
+	err = om.MoveToFront(5)
+	assert.Nil(t, err)
+	assertOrderedPairsEqual(t, om,
+		[]any{5, "1", 2, 6, "4", "7", "8", 3},
+		[]any{"28", "bar", 28, "100", "baz", "baz", "baz", 100})
+
+	err = om.MoveToFront(100)
+	assert.NotEqual(t, err, nil)
+}


### PR DESCRIPTION
Introduced a new file `map/map.go` implementing an OrderedMap feature. This provides a map data structure maintaining the insertion order of the data, which is particularly beneficial when the use case requires to remember the order of data addition. Further, the `encoding/yaml/yaml.go` file was updated to use `any` type for data encoding/decoding to and from yaml, improving the generality of the application. Additionally, a corresponding test file `map/map_test.go` was added for comprehensive testing of the new `OrderedMap` feature. Also, introduced necessary dependencies in `go.mod`.

The OrderedMap feature will enhance the versatility of data handling within the application, and updates in yaml encoding provide a broader usage of the encoding feature.